### PR TITLE
Update Match_species.R

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,5 @@
 ^\.git$
 cran-comments.md
 ^\.travis\.yml$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.so
 .Rhistory
 
+*.Rproj
+*.Rproj.user
+.Rproj.user

--- a/R/Match_species.R
+++ b/R/Match_species.R
@@ -17,11 +17,12 @@ Match_species = function( genus_species="Sebastes jordani", ParentChild_gz=FishL
   match_taxonomy = full_taxonomy = rfishbase::fishbase[Which,c("Class","Order","Family","Genus","Species")]
 
   # Match in database
-  Count = 1
+  Count = 0
   Group = NA
   while( is.na(Group) ){
     Group = match( paste(tolower(match_taxonomy),collapse="_"), tolower(ParentChild_gz[,'ChildName']) )
-    if( is.na(Group) ) rev(match_taxonomy)[Count] = "predictive"
+    if( is.na(Group)){ match_taxonomy [ncol(match_taxonomy) - Count] <- "predictive" } 
+    Count <- Count + 1
   }
   message( "Found match: ", paste(match_taxonomy,collapse=", ") )
 

--- a/R/Match_species.R
+++ b/R/Match_species.R
@@ -12,7 +12,7 @@
 Match_species = function( genus_species="Sebastes jordani", ParentChild_gz=FishLife::database$ParentChild_gz ){
   # Match full taxonomy from fishbase
   genus_species = strsplit( tolower(genus_species), split=c(" ","_"))[[1]]
-  Which = which( tolower(rfishbase::fishbase[,'Genus'])==genus_species[1] & tolower(rfishbase::fishbase[,'Species'])==genus_species[2] )
+  Which = which( tolower(rfishbase::fishbase$Genus)==genus_species[1] & tolower(rfishbase::fishbase$Species)==genus_species[2] )
   if( length(Which)!=1 ) stop("Couldn't match input in fishbase")
   match_taxonomy = full_taxonomy = rfishbase::fishbase[Which,c("Class","Order","Family","Genus","Species")]
 


### PR DESCRIPTION
Seems like `rfishbase::fishbase` switched to a `tibble` (`rfishbase` version 2.99). Running `tolower` on a column of a `data_frame` indexed by [,'Genus'] does some strange stuff since `tolower` takes a vector and [,"Genus"] on a tibble returns a `data_frame`.  Simple fix to just using tolower(rfishbase::fishbase$Genus)/ tolower(rfishbase::fishbase$Species) instead (and using `$` is actually a bit faster for `data_frames`, though doesn't matter much in this context)

``` r
tolower(rfishbase::fishbase[1:10,"Genus"])
#> [1] "c(\"abyssocottus\", \"abyssocottus\", \"abyssocottus\", \"asprocottus\", \"asprocottus\", \"asprocottus\", \"asprocottus\", \"asprocottus\", \"asprocottus\", \"asprocottus\")"


tolower(rfishbase::fishbase$Genus[1:10])
#>  [1] "abyssocottus" "abyssocottus" "abyssocottus" "asprocottus" 
#>  [5] "asprocottus"  "asprocottus"  "asprocottus"  "asprocottus" 
#>  [9] "asprocottus"  "asprocottus"
```

<sup>Created on 2018-10-23 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>